### PR TITLE
The bytesocksURL in the configuration page is incorrect

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,7 +70,7 @@ The default value is `"https://spark-usercontent.lucko.me/"`.
 }
 ```
 
-### `bytesocksUrl`
+### `bytesocksHost`
 The hostname for the bytesocks instance which should be used for communicating with the spark viewer.
 
 The default value is `"spark-usersockets.lucko.me"`.
@@ -78,7 +78,7 @@ The default value is `"spark-usersockets.lucko.me"`.
 #### Example
 ```json
 {
-    "bytesocksUrl": "spark-usersockets.lucko.me"
+    "bytesocksHost": "spark-usersockets.lucko.me"
 }
 ```
 


### PR DESCRIPTION
I have tried multiple times to modify this configuration item to send bytesocks requests to the self built server, but it has failed. After checking the source code, I found that the configuration item `bytesocksURL` should be `bytesocksHost`